### PR TITLE
[ TOOLS ][ YARI PARSER ] Links parsed open to new tab now (11/11 tests passed).

### DIFF
--- a/tools/yari.parser.js
+++ b/tools/yari.parser.js
@@ -87,7 +87,7 @@ function replaceHTMLGlossaryLinks(textContent, fileName) {
       link = `${baseLink}${p1[0].toUpperCase() + p1.slice(1).replace(/\s+/g, "_")}`;
     }
 
-    const output = `${openingTag}<a href="${link}">${p2 ? p2 : p1}</a>${closingTag}`;
+    const output = `${openingTag}<a href="${link}" target="_blank">${p2 ? p2 : p1}</a>${closingTag}`;
     // console.log({ match, output });
     // console.log(match, p1, p2);
     return output;
@@ -125,7 +125,7 @@ function replaceGlossaryLinks(textContent, fileName) {
       link = `${baseLink}${p1[0].toUpperCase() + p1.slice(1).replace(/\s+/g, "_")}`;
     }
 
-    const output = p2 ? `[${p2}](${link})` : `[${p1}](${link})`;
+    const output = `[${p2 ? p2 : p1}](${link}){:target="_blank"}`;
     // console.log(match, p1, p2);
     return output;
   }
@@ -194,7 +194,7 @@ function replaceDOMXrefLinks(textContent, fileName) {
 
     }
 
-    const output = p2 ? `[${p2}](${link})` : `[${p1}](${link})`;
+    const output = `[${p2 ? p2 : p1}](${link}){:target="_blank"}`;
     return output;
   }
 
@@ -220,7 +220,7 @@ function parseMDNLinks(textContent) {
       // console.log( linkText); // Link label
       // console.log( url ); // Link URL: /en-us/docs/...
       const newUrl = domain + url;
-      return `[${linkText}](${newUrl})`;
+      return `[${linkText}](${newUrl}){:target="_blank"}`;
     });
   }
 
@@ -251,7 +251,7 @@ function parseElementTerm(textContent) {
   const pattern = /{{(htmlelement|HTMLElement)\(['"](.*?)['"](?:, "(.*?)")?\)}}/g;
   return textContent.replace(pattern, (match, _, termA, termB) => {
     const link = `${URL}${termA}`;
-    return `[\`<${termB ? termB : termA}>\`](${link})`;
+    return `[\`<${termB ? termB : termA}>\`](${link}){:target="_blank"}`;
   })
 }
 
@@ -261,7 +261,7 @@ function parseCSSTerm(textContent) {
   const domain = "https://developer.mozilla.org/en-US/docs/Web/CSS/";
   const regex = /{{cssxref\("([^"]+)"\)}}/g;
   return textContent.replace(regex, (match, cssTerm) => {
-    return `[\`${cssTerm}\`](${domain}${cssTerm})`
+    return `[\`${cssTerm}\`](${domain}${cssTerm}){:target="_blank"}`
   })
 }
 
@@ -270,7 +270,7 @@ function parseHTTPStatus(textContent) {
   const pattern = /{{(HTTPStatus)\("(.*?)"(?:, "(.*?)")?\)}}/g;
   return textContent.replace(pattern, (match, _, termA, termB) => {
     const link = `${URL}${termA}`;
-    const output = `[${termB ? termB : termA}](${link})`;
+    const output = `[${termB ? termB : termA}](${link}){:target="_blank"}`;
     // console.log({ output }); 
     return output;
   })
@@ -281,7 +281,7 @@ function parseHTTPHeader(textContent) {
   const pattern = /{{(HTTPHeader)\("(.*?)"(?:, "(.*?)")?\)}}/g;
   return textContent.replace(pattern, (match, _, termA, termB) => {
     const link = `${URL}${termA}`;
-    const output = `[${termB ? termB : termA}](${link})`;
+    const output = `[${termB ? termB : termA}](${link}){:target="_blank"}`;
     console.log();
     info(`Found: ${match}`);
     console.log();

--- a/tools/yari.parser.test.js
+++ b/tools/yari.parser.test.js
@@ -6,40 +6,40 @@ const { parseEmbedGHLiveSample, parseHTTPHeader, parseHTTPStatus, parseYariDynam
 test('Parsing {{glossary("XML")}}', () => {
   const input = `{{glossary("XML")}}`;
   const output = parseYariDynamicContent(input);
-  equal(output, "[XML](https://developer.mozilla.org/en-US/docs/Glossary/XML)");
+  equal(output, "[XML](https://developer.mozilla.org/en-US/docs/Glossary/XML){:target=\"_blank\"}");
 });
 
 test('Parsing {{glossary("term")}}', () => {
   
   const input = `{{glossary("HTML")}}`;
   const output = parseYariDynamicContent(input);
-  equal(output, "[HTML](https://developer.mozilla.org/en-US/docs/Glossary/HTML)");
+  equal(output, "[HTML](https://developer.mozilla.org/en-US/docs/Glossary/HTML){:target=\"_blank\"}");
 
   const input2 = `{{Glossary("browser")}}`;
   const output2 = parseYariDynamicContent(input2);
-  equal(output2, "[browser](https://developer.mozilla.org/en-US/docs/Glossary/Browser)");
+  equal(output2, "[browser](https://developer.mozilla.org/en-US/docs/Glossary/Browser){:target=\"_blank\"}");
 
 });
 
 test('Parsing {{glossary("1", "2")}}', () => {
   const input = `{{glossary("attribute", "attributes")}}`;
   const output = parseYariDynamicContent(input);
-  equal(output, "[attributes](https://developer.mozilla.org/en-US/docs/Glossary/Attribute)");
+  equal(output, "[attributes](https://developer.mozilla.org/en-US/docs/Glossary/Attribute){:target=\"_blank\"}");
 
   const input2 = `{{glossary("void element", "void elements")}}`;
   const output2 = parseYariDynamicContent(input2);
-  equal(output2, "[void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)");
+  equal(output2, "[void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element){:target=\"_blank\"}");
 
   const input3 = `{{Glossary("tag", "tags")}}`;
   const output3 = parseYariDynamicContent(input3);
-  equal(output3, "[tags](https://developer.mozilla.org/en-US/docs/Glossary/Tag)");
+  equal(output3, "[tags](https://developer.mozilla.org/en-US/docs/Glossary/Tag){:target=\"_blank\"}");
 
 });
 
 test("Parsing <tag>{{Glossary()}}</tag>", ()=>{
 
   const input = `<tr><th scope="row">{{Glossary("String")}}</th></tr>`;
-  const output = `<tr><th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Glossary/String">String</a></th></tr>`;
+  const output = `<tr><th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Glossary/String" target="_blank">String</a></th></tr>`;
   equal( output, replaceHTMLGlossaryLinks(input) );
 
 });
@@ -48,7 +48,7 @@ test("Replacing MDN relative links with absolute URLs", () => {
 
   const input = `lorem ipsum [What will your website look like?](/en-US/docs/Learn/Getting_started_with_the_web/What_will_your_website_look_like#font) lorem ipsum`;
   const output = parseMDNLinks(input);
-  equal(output, "lorem ipsum [What will your website look like?](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/What_will_your_website_look_like#font) lorem ipsum");
+  equal(output, "lorem ipsum [What will your website look like?](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/What_will_your_website_look_like#font){:target=\"_blank\"} lorem ipsum");
   
 });
 
@@ -68,11 +68,11 @@ test("Replacing {{htmlelement}} with links", ()=>{
   const input4 = `{{HTMLElement("p")}}`
   const input5 = `{{htmlelement("p")}}`
 
-  const output1 = "[`<h1>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)"
-  const output2 = "[`<body>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)"
-  const output3 = "[`<head>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)"
-  const output4 = "[`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)"
-  const output5 = "[`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)"
+  const output1 = "[`<h1>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements){:target=\"_blank\"}"
+  const output2 = "[`<body>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body){:target=\"_blank\"}"
+  const output3 = "[`<head>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head){:target=\"_blank\"}"
+  const output4 = "[`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p){:target=\"_blank\"}"
+  const output5 = "[`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p){:target=\"_blank\"}"
 
   equal(parseElementTerm(input1), output1);
   equal(parseElementTerm(input2), output2);
@@ -81,7 +81,7 @@ test("Replacing {{htmlelement}} with links", ()=>{
   equal(parseElementTerm(input5), output5);
 
   const input6  = `lorem ipsum {{HTMLElement('i')}} lorem ipsum`
-  const output6 = `lorem ipsum [\`<i>\`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i) lorem ipsum`
+  const output6 = `lorem ipsum [\`<i>\`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i){:target=\"_blank\"} lorem ipsum`
 
   equal( parseElementTerm(input6), output6 );
 
@@ -90,7 +90,7 @@ test("Replacing {{htmlelement}} with links", ()=>{
 test("Replacing {{cssxref}} with links", ()=>{
 
   const input = `lorem ipsum {{cssxref("width")}} lorem ipsum`;
-  const output = "lorem ipsum [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width) lorem ipsum";
+  const output = "lorem ipsum [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width){:target=\"_blank\"} lorem ipsum";
   equal(parseCSSTerm(input), output);
 
 })
@@ -98,7 +98,7 @@ test("Replacing {{cssxref}} with links", ()=>{
 test("Replacing {{HTTPStatus}} with links", ()=>{
 
   const input = `lorem ipsum {{HTTPStatus("404", "404 Not Found")}} lorem ipsum`;
-  const output = "lorem ipsum [404 Not Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404) lorem ipsum";
+  const output = "lorem ipsum [404 Not Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404){:target=\"_blank\"} lorem ipsum";
   equal(parseHTTPStatus(input), output);
 
 })
@@ -106,21 +106,21 @@ test("Replacing {{HTTPStatus}} with links", ()=>{
 test("Replacing {{domxref}}", ()=>{
 
   const input1 = `lorem ipsum {{domxref("Document.querySelector", "querySelector()")}} lorem ipsum`;
-  const output1 = `lorem ipsum [querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) lorem ipsum`;
+  const output1 = `lorem ipsum [querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector){:target=\"_blank\"} lorem ipsum`;
   equal( output1, replaceDOMXrefLinks(input1) );
   
   const input2 = `lorem ipsum {{domxref("Node.textContent", "textContent")}} lorem ipsum`; 
-  const output2 = `lorem ipsum [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) lorem ipsum`; 
+  const output2 = `lorem ipsum [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent){:target=\"_blank\"} lorem ipsum`; 
 
   equal( output2, replaceDOMXrefLinks(input2) );
 
   const input3 = `lorem ipsum {{domxref("Element/click_event", "click")}} lorem ipsum`;
-  const output3 = `lorem ipsum [click](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) lorem ipsum`; 
+  const output3 = `lorem ipsum [click](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event){:target=\"_blank\"} lorem ipsum`; 
 
   equal( output3, replaceDOMXrefLinks(input3) );
 
   const input4 = `lorem ipsum {{domxref("WebRTC API", "WebRTC")}} lorem ipsum`
-  const output4 = `lorem ipsum [WebRTC](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API) lorem ipsum`
+  const output4 = `lorem ipsum [WebRTC](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API){:target=\"_blank\"} lorem ipsum`
 
   equal( output4, replaceDOMXrefLinks(input4) );
 
@@ -129,7 +129,7 @@ test("Replacing {{domxref}}", ()=>{
 test("Replacing {{HTTPHeader}} with links", ()=>{
 
   const input = `lorem ipsum {{HTTPHeader("Content-Security-Policy")}} lorem ipsum`;
-  const output = "lorem ipsum [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) lorem ipsum";
+  const output = "lorem ipsum [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy){:target=\"_blank\"} lorem ipsum";
   equal(parseHTTPHeader(input), output);
 
 })


### PR DESCRIPTION
Now the yari.parser tool inserts '{:target="blank"}' at the end of MDN links.

However, this does not occur when the parser finds external links (not of the MDN domain) as it does not treat them as text elements that have to be altered/replaces.
I suggest we add that functionality sometime.